### PR TITLE
stops drinks with same name getting added to venues

### DIFF
--- a/lib/cs_guide_web/controllers/venue_controller.ex
+++ b/lib/cs_guide_web/controllers/venue_controller.ex
@@ -124,7 +124,7 @@ defmodule CsGuideWeb.VenueController do
 
     render(conn, "add_drinks.html",
       brands: brands,
-      current_drinks: Enum.map(venue.drinks, fn d -> d.name end),
+      current_drinks: Enum.map(venue.drinks, fn d -> d.entry_id end),
       changeset: changeset,
       action: venue_path(conn, :update, venue.entry_id)
     )

--- a/lib/cs_guide_web/templates/venue/add_drinks.html.eex
+++ b/lib/cs_guide_web/templates/venue/add_drinks.html.eex
@@ -11,7 +11,7 @@
           <div id="drink-list-<%= i %>" class="dn pt1">
             <%= for d <- b.drinks do %>
               <div class="mv1 pl3">
-                <%= checkbox(f, String.to_atom(d.name), name: "venue[drinks][#{String.to_atom(d.entry_id)}]", value: d.name in @current_drinks, class: "") %>
+                <%= checkbox(f, String.to_atom(d.name), name: "venue[drinks][#{String.to_atom(d.entry_id)}]", value: d.entry_id in @current_drinks, class: "") %>
                 <%= label f, String.to_atom(d.name) %>
               </div>
             <% end %>


### PR DESCRIPTION
ref #164

Fixes bug where the add drinks form displayed that a venue stocked all drinks of a certain name if it stocked one of them.