### PR TITLE
allow drink to be created under a brand

### DIFF
--- a/lib/cs_guide_web/templates/drink/new.html.eex
+++ b/lib/cs_guide_web/templates/drink/new.html.eex
@@ -2,7 +2,7 @@
   <h2 class="f4 lh4">New Drink</h2>
 
   <%= custom_render_autoform(@conn, :create, [
-    {CsGuide.Resources.Drink, exclude: [:description, :drink_types, :drink_styles, :brand_id, :weighting, :abv]},
+    {CsGuide.Resources.Drink, exclude: [:description, :drink_types, :drink_styles, :brand_id, :brand, :ingredients, :weighting, :abv]},
     """
     <div class="form-group">
       <label class="control-label " for="drink_abv">ABV</label>
@@ -14,7 +14,7 @@
     </div>
     """,
     {CsGuide.Resources.Drink, exclude: [:description, :abv, :name], custom_labels: %{drink_styles: "Drink Style", drink_types: "Drink Type"}},
-  ], exclude: [:entry_id, :deleted, :venues, :brand, :drink_images], update_field: :entry_id, assoc_query: &query/1, assigns: [changeset: @changeset]) %>
+  ], exclude: [:entry_id, :deleted, :venues, :brand_id, :drink_images], update_field: :entry_id, assoc_query: &query/1, assigns: [changeset: @changeset]) %>
 
   <span><%= link "Back", to: drink_path(@conn, :index) %></span>
 </section>


### PR DESCRIPTION
ref: #181

exclude field `brand_id` from the form and instead use the field `brand` which display all the possible brand in a dropdown