### PR TITLE
Allow multiples of 0.01 in abv input

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule CsGuide.Mixfile do
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
       {:nimble_csv, "~> 0.3"},
-      {:autoform, git: "https://github.com/dwyl/autoform.git", tag: "0.4.0"},
+      {:autoform, git: "https://github.com/dwyl/autoform.git", tag: "0.5.0"},
       {:alog, git: "https://github.com/dwyl/alog.git", tag: "0.2"},
       {:ex_aws, "~> 2.0"},
       {:ex_aws_s3, "~> 2.0"},


### PR DESCRIPTION
updates autoform, applies default step of 0.01 to number inputs of type `:float`
ref #107

- [x] Needs autoform 0.5 to be released before merging