### PR TITLE
Search Styling #130 #44

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -41,6 +41,21 @@ select {
   color: #333333;
 }
 
+/* Colour of placeholder input text */
+
+::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #999999;
+}
+::-moz-placeholder { /* Firefox 19+ */
+  color: #999999;
+}
+:-ms-input-placeholder { /* IE 10+ */
+  color: #999999;
+}
+:-moz-placeholder { /* Firefox 18- */
+  color: #999999;
+}
+
 .bg-cs-black {
   background-color: #333333;
 }

--- a/assets/elm/Search.elm
+++ b/assets/elm/Search.elm
@@ -6,12 +6,13 @@ import Html.Events exposing (..)
 import Json.Decode as Json exposing (..)
 
 
-renderFilter : String -> List String -> (String -> msg) -> Html msg
-renderFilter defaultTitle dropdownItems msgConstructor =
+renderFilter : String -> List String -> (String -> msg) -> String -> Html msg
+renderFilter defaultTitle dropdownItems msgConstructor selected =
     div [ class "dib pr2" ]
         [ select
             [ onChange msgConstructor
-            , class "f6 lh6 cs-light-gray bg-white b--cs-light-gray br2 bw1 pv2 ph3 dib w6"
+            , class "f6 lh6 bg-white b--cs-gray br2 bw1 pv2 ph3 dib w6"
+            , classList [("cs-gray", ( selected == "" ))]
             ]
             ([ option [ Html.Attributes.value "" ] [ text defaultTitle ] ]
                 ++ List.map (\dropdownItem -> renderDropdownItems dropdownItem) dropdownItems
@@ -26,12 +27,12 @@ renderDropdownItems dropdownItem =
 
 renderSearch : String -> (String -> msg) -> Html msg
 renderSearch text msg =
-    div [ class "dib pr2" ]
+    div [ class "db mb3 w-50" ]
         [ input
             [ type_ "text"
             , placeholder text
             , onInput msg
-            , class "f6 lh6 cs-light-gray bg-white b--cs-light-gray br2 bw1 pv2 pl3 dib w6"
+            , class "f6 lh6 cs-black bg-white ba b--cs-light-gray br2 pv2 pl3 pr6"
             ]
             []
         ]

--- a/assets/elm/SearchDrink.elm
+++ b/assets/elm/SearchDrink.elm
@@ -127,11 +127,11 @@ view : Model -> Html Msg
 view model =
     div [ class "mt6" ]
         [ div [ class "w-90 center" ]
-            [ (renderFilter "Drink Type" drink_types SelectDrinkType)
-            , (renderFilter "ABV" abv_levels SelectABVLevel)
-            , (renderSearch "Search drinks..." SearchDrink)
+            [ (renderSearch "Search Drinks..." SearchDrink)
+            , (renderFilter "Drink Type" drink_types SelectDrinkType model.dtype_filter)
+            , (renderFilter "ABV" abv_levels SelectABVLevel model.abv_filter)
             ]
-        , div [ class "relative" ]
+        , div [ class "relative center w-90" ]
             [ div [ class "flex-ns flex-wrap justify-center pt3 pb4-ns db dib-ns" ]
                 (filterDrinks model)
             ]
@@ -200,7 +200,7 @@ renderDrinks drinks =
             |> toList
     else
         [ div []
-            [ p [] [ text "Your search didn't return any drinks, change your filters and try again." ]
+            [ p [class "tc"] [ text "Your search didn't return any drinks, change your filters and try again." ]
             ]
         ]
 

--- a/assets/elm/SearchVenue.elm
+++ b/assets/elm/SearchVenue.elm
@@ -83,9 +83,13 @@ view : Model -> Html Msg
 view model =
     div [ class "mt6" ]
         [ div [ class "w-90 center" ]
-            [ (renderFilter "Venue Type" venue_types FilterVenueType)
-            , (renderFilter "Score" cs_score FilterVenueScore)
-            , (renderSearch "Venue Name" FilterVenueName)
+            [ (renderSearch "Search Venues..." FilterVenueName)
+            , (renderFilter "Venue Type" venue_types FilterVenueType (Maybe.withDefault "" model.filterType))
+            , (renderFilter "Score" cs_score FilterVenueScore (case model.filterScore of
+              Just score -> String.fromFloat score
+              Nothing -> ""
+              )
+            )
             ]
         , div [ class "w-90 center" ]
             [ div []
@@ -135,8 +139,8 @@ filterByScore score venues =
 renderVenues : List Venue -> List (Html Msg)
 renderVenues venues =
     if List.isEmpty venues then
-        [ div []
-            [ p [] [ text "Your search didn't return any venues, change your filters and try again." ]
+        [ div [class "flex-ns flex-wrap justify-center pt3 pb4-ns db dib-ns"]
+            [ p [ class "tc"] [ text "Your search didn't return any venues, change your filters and try again." ]
             ]
         ]
     else


### PR DESCRIPTION
Ref: #130 #44

![image](https://user-images.githubusercontent.com/16775804/49509717-08ae2b80-f87e-11e8-92bd-d525997304ea.png)

![image](https://user-images.githubusercontent.com/16775804/49509736-15328400-f87e-11e8-91d8-8ac7052e4b5f.png)

- Amends search styling on drinks and venues pages:
  - solid borders
  - grey placeholder text and black selected/ input text
  - Puts the search bar before filters and makes it wider
  - Organises styling on mobile and gives padding to no results text