### PR TITLE
Removes password and admin field from user form

### DIFF
--- a/lib/cs_guide_web/templates/user/new.html.eex
+++ b/lib/cs_guide_web/templates/user/new.html.eex
@@ -4,7 +4,7 @@
   takes is your email and a password.</p>
 
   <%= custom_render_autoform(@conn, :create, [
-    {CsGuide.Accounts.User, exclude: [:email_hash]},
+    {CsGuide.Accounts.User, exclude: [:email_hash, :password, :admin]},
     "<h3 class=\"f4 lh4 mt3\">Set Up a Venue</h3>",
     "<h2 class=\"f5 lh5 mt3 mb2\">Basic Information</h2>",
     "<p class=\"f6 lh6 cs-pink mb3\">* - required field</p>",


### PR DESCRIPTION
Passwords are not required for regular users yet so shouldn't show up on the signup form, and the admin field shouldn't display either.