### PR TITLE
#8 Mends drinks carousel

### DIFF
--- a/assets/elm/DrinksCarousel.elm
+++ b/assets/elm/DrinksCarousel.elm
@@ -94,7 +94,7 @@ update msg model =
         IncrementIndexes ->
             let
                 newIndex =
-                    if model.carouselIndex <= 1 then
+                    if model.carouselIndex <= 8 then
                         model.carouselIndex + 1
                     else
                         0
@@ -116,7 +116,7 @@ update msg model =
                 newIndex =
                     case dir of
                         "right" ->
-                            if model.carouselIndex >= 1 then
+                            if model.carouselIndex >= 8 then
                                 model.carouselIndex - 1
                             else
                                 11
@@ -158,7 +158,33 @@ view model =
 
 renderDrinksCarousel : Model -> Int -> List (Html Msg)
 renderDrinksCarousel model displayXDrinks =
-    Array.fromList model.drinks
+  let
+      arrayIsFour =
+        if (Array.fromList model.drinks
+          |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
+          |> Array.length) == 4
+        then
+          True
+        else
+          False
+
+      originalFour =
+        Array.fromList model.drinks
+          |> Array.slice 0 4
+          |> Array.indexedMap drinkCard
+  in
+    if arrayIsFour then
+      Array.fromList model.drinks
         |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
         |> Array.indexedMap drinkCard
+        |> toList
+    else
+      -- Add from the original array to the new array
+      -- Need the values from the original array to concat to the end
+      -- Need to know how much of the original array you need or could slice on 4?
+      Array.fromList model.drinks
+        |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
+        |> Array.indexedMap drinkCard
+        |> append(originalFour)
+        |> Array.slice 0 4
         |> toList

--- a/assets/elm/DrinksCarousel.elm
+++ b/assets/elm/DrinksCarousel.elm
@@ -1,16 +1,16 @@
-port module DrinksCarousel exposing (..)
+port module DrinksCarousel exposing (HttpData, Model, Msg(..), drinkDecoder, drinksDecoder, getDrinkByIndex, getDrinks, init, main, renderDrinksCarousel, subscriptions, swipe, update, view)
 
+import Array exposing (..)
 import Browser
+import DrinkCard exposing (drinkCard)
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
 import Http
 import Json.Decode as Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
-import Html exposing (..)
-import Html.Events exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (onClick)
-import Array exposing (..)
 import SharedTypes exposing (Drink)
-import DrinkCard exposing (drinkCard)
+
 
 
 -- MAIN
@@ -31,7 +31,7 @@ main =
 
 getDrinks : Cmd Msg
 getDrinks =
-    Http.get ("/json_drinks") drinksDecoder |> Http.send ReceiveDrinks
+    Http.get "/json_drinks" drinksDecoder |> Http.send ReceiveDrinks
 
 
 drinksDecoder : Decoder (List Drink)
@@ -77,8 +77,8 @@ init _ =
 
 type Msg
     = ReceiveDrinks (HttpData (List Drink))
-    | IncrementIndexes
-    | DecrementIndexes
+    | CarouselRight
+    | CarouselLeft
     | Swipe String
 
 
@@ -91,46 +91,26 @@ update msg model =
         ReceiveDrinks (Ok drinks) ->
             ( { model | drinks = drinks }, Cmd.none )
 
-        IncrementIndexes ->
-            let
-                newIndex =
-                    if model.carouselIndex <= 8 then
-                        model.carouselIndex + 1
-                    else
-                        0
-            in
-                ( { model | carouselIndex = newIndex }, Cmd.none )
+        CarouselLeft ->
+            ( { model | carouselIndex = modBy 12 model.carouselIndex + 1 }, Cmd.none )
 
-        DecrementIndexes ->
-            let
-                newIndex =
-                    if model.carouselIndex >= 1 then
-                        model.carouselIndex - 1
-                    else
-                        11
-            in
-                ( { model | carouselIndex = newIndex }, Cmd.none )
+        CarouselRight ->
+            ( { model | carouselIndex = modBy 12 model.carouselIndex - 1 }, Cmd.none )
 
         Swipe dir ->
             let
                 newIndex =
                     case dir of
                         "right" ->
-                            if model.carouselIndex >= 8 then
-                                model.carouselIndex - 1
-                            else
-                                11
+                            modBy 12 model.carouselIndex - 1
 
                         "left" ->
-                            if model.carouselIndex <= 1 then
-                                model.carouselIndex + 1
-                            else
-                                0
+                            modBy 12 model.carouselIndex + 1
 
                         _ ->
                             model.carouselIndex
             in
-                ( { model | carouselIndex = newIndex }, Cmd.none )
+            ( { model | carouselIndex = newIndex }, Cmd.none )
 
 
 port swipe : (String -> msg) -> Sub msg
@@ -148,43 +128,23 @@ subscriptions model =
 view : Model -> Html Msg
 view model =
     div [ class "relative" ]
-        [ p [ class "dn db-ns f1 b pointer absolute-vertical-center left-2", onClick DecrementIndexes ] [ text "<" ]
+        [ p [ class "dn db-ns f1 b pointer absolute-vertical-center left-2", onClick CarouselLeft ] [ text "<" ]
         , div [ class "flex-ns flex-wrap justify-center pv4-ns dn dib-ns" ]
-            (renderDrinksCarousel model 4)
+            (renderDrinksCarousel model 3)
         , div [ class "flex-wrap justify-center db dn-ns", id "carousel" ]
-            (renderDrinksCarousel model 1)
-        , p [ class "dn db-ns f1 b pointer absolute-vertical-center right-2", onClick IncrementIndexes ] [ text ">" ]
+            (renderDrinksCarousel model 0)
+        , p [ class "dn db-ns f1 b pointer absolute-vertical-center right-2", onClick CarouselRight ] [ text ">" ]
         ]
+
 
 renderDrinksCarousel : Model -> Int -> List (Html Msg)
 renderDrinksCarousel model displayXDrinks =
-  let
-      arrayIsFour =
-        if (Array.fromList model.drinks
-          |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
-          |> Array.length) == 4
-        then
-          True
-        else
-          False
+    List.range model.carouselIndex (model.carouselIndex + displayXDrinks)
+        |> List.map (\index -> getDrinkByIndex model <| modBy 12 index)
+        |> List.indexedMap drinkCard
 
-      originalFour =
-        Array.fromList model.drinks
-          |> Array.slice 0 4
-          |> Array.indexedMap drinkCard
-  in
-    if arrayIsFour then
-      Array.fromList model.drinks
-        |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
-        |> Array.indexedMap drinkCard
-        |> toList
-    else
-      -- Add from the original array to the new array
-      -- Need the values from the original array to concat to the end
-      -- Need to know how much of the original array you need or could slice on 4?
-      Array.fromList model.drinks
-        |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
-        |> Array.indexedMap drinkCard
-        |> append(originalFour)
-        |> Array.slice 0 4
-        |> toList
+
+getDrinkByIndex model index =
+    Array.fromList model.drinks
+        |> Array.get index
+        |> Maybe.withDefault (Drink "" "" "" 0.0 [] [] "" "")

--- a/assets/elm/DrinksCarousel.elm
+++ b/assets/elm/DrinksCarousel.elm
@@ -148,15 +148,17 @@ subscriptions model =
 view : Model -> Html Msg
 view model =
     div [ class "relative" ]
-        [ p [ class "f1 b pointer absolute-vertical-center left-2", onClick DecrementIndexes ] [ text "<" ]
-        , div [ class "flex-ns flex-wrap justify-center pv4-ns db dib-ns", id "carousel" ]
-            (renderDrinksCarousel model)
-        , p [ class "f1 b pointer absolute-vertical-center right-2", onClick IncrementIndexes ] [ text ">" ]
+        [ p [ class "dn db-ns f1 b pointer absolute-vertical-center left-2", onClick DecrementIndexes ] [ text "<" ]
+        , div [ class "flex-ns flex-wrap justify-center pv4-ns dn dib-ns" ]
+            (renderDrinksCarousel model 4)
+        , div [ class "flex-wrap justify-center db dn-ns", id "carousel" ]
+            (renderDrinksCarousel model 1)
+        , p [ class "dn db-ns f1 b pointer absolute-vertical-center right-2", onClick IncrementIndexes ] [ text ">" ]
         ]
 
-
-renderDrinksCarousel model =
+renderDrinksCarousel : Model -> Int -> List (Html Msg)
+renderDrinksCarousel model displayXDrinks =
     Array.fromList model.drinks
-        |> Array.slice model.carouselIndex (model.carouselIndex + 4)
+        |> Array.slice model.carouselIndex (model.carouselIndex + displayXDrinks)
         |> Array.indexedMap drinkCard
         |> toList

--- a/lib/cs_guide_web/controllers/drink_controller.ex
+++ b/lib/cs_guide_web/controllers/drink_controller.ex
@@ -22,7 +22,20 @@ defmodule CsGuideWeb.DrinkController do
 
     json(
       conn,
-      Enum.sort_by(drinks, fn d -> Map.get(d, :weighting, 0) end, &>=/2)
+      Enum.sort_by(
+        drinks,
+        fn d ->
+          case Map.get(d, :weighting) do
+            nil ->
+              0
+
+            n ->
+              n
+          end
+        end,
+        &>=/2
+      )
+      |> Enum.slice(0, 12)
       |> Enum.map(fn d ->
         %{
           name: d.name,


### PR DESCRIPTION
#8 Mends drinks carousel:
- removes arrows and displays only one card on mobile
- Fixes carousel looping
- Fixes weighting bug where drinks from seeds file were ahead of weighted drinks