### PR TITLE
#236 Updates z-indexes so burger menu is on top of filters

### DIFF
--- a/assets/elm/SearchDrink.elm
+++ b/assets/elm/SearchDrink.elm
@@ -133,7 +133,7 @@ criteriaConfig =
 
 mainDivAttrs : List (Attribute Msg)
 mainDivAttrs =
-    [ class "relative bg-white dib z-max" ]
+    [ class "relative bg-white dib z-1" ]
 
 
 filtersDivAttrs : List (Attribute Msg)

--- a/lib/cs_guide_web/templates/layout/app.html.eex
+++ b/lib/cs_guide_web/templates/layout/app.html.eex
@@ -15,7 +15,7 @@
 
   <body>
     <header>
-      <nav role="navigation" class="absolute top-0 left-0 z-1 flex flex-wrap items-center w-100">
+      <nav role="navigation" class="absolute top-0 left-0 z-2 flex flex-wrap items-center w-100">
         <div class="w-60 w-20-ns mv3">
           <a href="/">
             <img src="<%= static_path(@conn, "/images/logo.png") %>" alt="Club Soda Logo" class="ml3 ml5-l">

--- a/lib/cs_guide_web/templates/venue/info.html.eex
+++ b/lib/cs_guide_web/templates/venue/info.html.eex
@@ -11,7 +11,8 @@
   <div class="tl pt3">
     <img class="w4 v-btm" src="<%= static_path(@conn, "/images/score-#{@venue.cs_score}.png") %>" alt="Club Soda Score of <%= @venue.cs_score %>">
     <%= if @is_authenticated do %>
-      <%= if @venue.cs_score == 0 do %>
+      <%= if @venue.cs_score == 5 do %>
+        <%= link "Is your stocklist up to date? Click here to update it.", to: venue_path(@conn, :add_drinks, @venue.entry_id), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
       <% else %>
         <%= link "Improve your score by adding more drinks to you stocklist.", to: venue_path(@conn, :add_drinks, @venue.entry_id), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
       <% end %>


### PR DESCRIPTION
#236 Updates z-indexes so burger menu is on top of filters
Updates cs score message for venues with score 5

The drink type dropdown had been assigned `z-max` which conflicted with the navbar which only had `z-1` meaning the burger menu sat beneath the dropdown. I've now increased the nav to `z-2` and made the drink type `z-1` so there's more scope for z-index alterations should they be needed in the future!