### PR TITLE
update autoform

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule CsGuide.Mixfile do
       {:gettext, "~> 0.11"},
       {:cowboy, "~> 1.0"},
       {:nimble_csv, "~> 0.3"},
-      {:autoform, git: "https://github.com/dwyl/autoform.git", tag: "0.6.3"},
+      {:autoform, git: "https://github.com/dwyl/autoform.git", tag: "0.6.4"},
       {:alog, git: "https://github.com/dwyl/alog.git", tag: "0.4.1"},
       {:ex_aws, "~> 2.0"},
       {:ex_aws_s3, "~> 2.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "alog": {:git, "https://github.com/dwyl/alog.git", "d1c27bdb6939f6ae9d67ef7ecd4707ec3267ebb8", [tag: "0.4.1"]},
   "argon2_elixir": {:hex, :argon2_elixir, "1.3.3", "487ffa071ef78c51d9b16e50ff3cf30cf8204e0aa4bdc8afd3765fdd8195e213", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, optional: false]}]},
-  "autoform": {:git, "https://github.com/dwyl/autoform.git", "98718842ec8487959c549e8c991a6f373d102521", [tag: "0.6.3"]},
+  "autoform": {:git, "https://github.com/dwyl/autoform.git", "582d42c36df4519f35fea02abb49c6fc6911b298", [tag: "0.6.4"]},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, optional: false]}]},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},


### PR DESCRIPTION
ref: #281
Update `autoform` to 0.6.4 to use the correct name for the schemas