### PR TITLE
Only filter venues with 'retailer' type from search and admin page

### DIFF
--- a/lib/cs_guide_web/controllers/retailer_controller.ex
+++ b/lib/cs_guide_web/controllers/retailer_controller.ex
@@ -10,12 +10,7 @@ defmodule CsGuideWeb.RetailerController do
       Venue.all()
       |> Venue.preload(:venue_types)
       |> Enum.filter(fn v ->
-        v.venue_types
-      end)
-      |> Enum.filter(fn v ->
-        if Enum.find(v.venue_types, fn type -> String.downcase(type.name) == "retailers" end) do
-          v
-        end
+        Enum.find(v.venue_types, fn type -> String.downcase(type.name) == "retailers" end)
       end)
       |> Enum.sort_by(& &1.venue_name)
 

--- a/lib/cs_guide_web/controllers/search_all_controller.ex
+++ b/lib/cs_guide_web/controllers/search_all_controller.ex
@@ -8,24 +8,23 @@ defmodule CsGuideWeb.SearchAllController do
       Venue.all()
       |> Venue.preload([:venue_types, :venue_images])
       |> Enum.filter(fn v ->
-        v.venue_types
-      end)
-      |> Enum.filter(fn v ->
-        if Enum.find(v.venue_types, fn type -> String.downcase(type.name) !== "retailers" end) do
-          v
-        end
+        !Enum.find(v.venue_types, fn type -> String.downcase(type.name) == "retailers" end)
       end)
       |> Enum.sort_by(&{5 - &1.cs_score, &1.venue_name})
 
     venue_cards = Enum.map(venues, fn v -> Venue.get_venue_card(v) end)
 
-    drinks = Drink.all()
-    |> Drink.preload([:brand, :drink_types, :drink_styles, :drink_images])
-    |> Enum.sort_by(fn d -> Map.get(d, :weighting, 0) end, &>=/2)
+    drinks =
+      Drink.all()
+      |> Drink.preload([:brand, :drink_types, :drink_styles, :drink_images])
+      |> Enum.sort_by(fn d -> Map.get(d, :weighting, 0) end, &>=/2)
 
     drink_cards = Enum.map(drinks, fn d -> Drink.get_drink_card(d) end)
 
-    render(conn, "index.html", venues: venue_cards, drinks: drink_cards, term: (params["term"] || ""))
+    render(conn, "index.html",
+      venues: venue_cards,
+      drinks: drink_cards,
+      term: params["term"] || ""
+    )
   end
-
 end

--- a/lib/cs_guide_web/controllers/search_venue_controller.ex
+++ b/lib/cs_guide_web/controllers/search_venue_controller.ex
@@ -8,18 +8,11 @@ defmodule CsGuideWeb.SearchVenueController do
       Venue.all()
       |> Venue.preload([:venue_types, :venue_images])
       |> Enum.filter(fn v ->
-        v.venue_types
-      end)
-      |> Enum.filter(fn v ->
-        if Enum.find(v.venue_types, fn type -> String.downcase(type.name) !== "retailers" end) do
-          v
-        end
+        !Enum.find(v.venue_types, fn type -> String.downcase(type.name) == "retailers" end)
       end)
       |> Enum.sort_by(&{5 - &1.cs_score, &1.venue_name})
 
     cards = Enum.map(venues, fn v -> Venue.get_venue_card(v) end)
     render(conn, "index.html", venues: cards)
   end
-
-
 end

--- a/lib/cs_guide_web/controllers/venue_controller.ex
+++ b/lib/cs_guide_web/controllers/venue_controller.ex
@@ -11,12 +11,7 @@ defmodule CsGuideWeb.VenueController do
       Venue.all()
       |> Venue.preload(:venue_types)
       |> Enum.filter(fn v ->
-        v.venue_types
-      end)
-      |> Enum.filter(fn v ->
-        if Enum.find(v.venue_types, fn type -> String.downcase(type.name) !== "retailers" end) do
-          v
-        end
+        !Enum.find(v.venue_types, fn type -> String.downcase(type.name) == "retailers" end)
       end)
       |> Enum.sort_by(& &1.venue_name)
 

--- a/test/cs_guide_web/controllers/search_venue_controller_test.exs
+++ b/test/cs_guide_web/controllers/search_venue_controller_test.exs
@@ -14,6 +14,12 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
       favourite: false,
       venue_types: %{"Pubs" => "on"},
       postcode: "SW1 4RV"
+    },
+    %{
+      venue_name: "The Retailer",
+      favourite: false,
+      venue_types: %{"Retailers" => "on"},
+      postcode: "SW1 4RV"
     }
   ]
 
@@ -31,11 +37,21 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
 
       assert html_response(conn, 200) =~ "The Not Favourite Pub"
     end
+
+    test "GET /search/venues doesn't contain retailer", %{conn: conn, venue: venue} do
+      conn = get(conn, "/search/venues")
+
+      refute html_response(conn, 200) =~ "The Retailer"
+    end
   end
 
   def fixture(:venue) do
     %Categories.VenueType{}
     |> Categories.VenueType.changeset(%{name: "Pubs"})
+    |> Categories.VenueType.insert()
+
+    %Categories.VenueType{}
+    |> Categories.VenueType.changeset(%{name: "Retailers"})
     |> Categories.VenueType.insert()
 
     @venues


### PR DESCRIPTION
ref #285

Fixes bug where venues that were missing their `venue_type` were not being displayed on the search or admin page.