### PR TITLE
#223 Gives venues readable slugs

### DIFF
--- a/assets/elm/Search.elm
+++ b/assets/elm/Search.elm
@@ -66,7 +66,7 @@ renderVenues venues =
 venueCard : Venue -> Html msg
 venueCard venue =
     div [ class "w-100 w-25-ns pb4" ]
-        [ a [ href <| "/venues/" ++ venue.id, class "cs-black no-underline pointer" ]
+        [ a [ href <| "/venues/" ++ venue.slug, class "cs-black no-underline pointer" ]
             [ if String.isEmpty venue.image then
                 div [ class "bg-green w-100 w-90-m w5-l h4 br2 mb2 bg-venue-card" ] []
 

--- a/assets/elm/SharedTypes.elm
+++ b/assets/elm/SharedTypes.elm
@@ -20,6 +20,7 @@ type alias Venue =
     , postcode : String
     , cs_score : Float
     , image : String
+    , slug : String
     }
 
 

--- a/lib/cs_guide/resources/venue.ex
+++ b/lib/cs_guide/resources/venue.ex
@@ -26,6 +26,7 @@ defmodule CsGuide.Resources.Venue do
     field(:lat, :float)
     field(:long, :float)
     field(:distance, :float, virtual: true)
+    field(:slug, :string)
 
     many_to_many(
       :venue_types,
@@ -74,10 +75,11 @@ defmodule CsGuide.Resources.Venue do
       :facebook,
       :favourite,
       :lat,
-      :long
+      :long,
+      :slug
     ])
     |> cast_assoc(:users)
-    |> validate_required([:venue_name, :postcode, :venue_types])
+    |> validate_required([:venue_name, :postcode, :venue_types, :slug])
   end
 
   def retailer_changeset(venue, attrs \\ %{}) do
@@ -131,7 +133,6 @@ defmodule CsGuide.Resources.Venue do
     |> Resources.put_many_to_many_assoc(attrs, :drinks, CsGuide.Resources.Drink, :entry_id)
     |> Repo.insert()
   end
-
 
   def get_venue_card(%__MODULE__{} = venue) do
     %{

--- a/lib/cs_guide/resources/venue.ex
+++ b/lib/cs_guide/resources/venue.ex
@@ -161,6 +161,20 @@ defmodule CsGuide.Resources.Venue do
     |> Resources.put_many_to_many_assoc(attrs, :venue_types, CsGuide.Categories.VenueType, :name)
     |> Resources.put_many_to_many_assoc(attrs, :drinks, CsGuide.Resources.Drink, :entry_id)
     |> Repo.insert()
+  end
 
+  def create_slug(name, postcode) do
+    Enum.join([name, "-", postcode])
+    |> change_spaces_to_dashes()
+    |> String.replace(~r/(,|')/, "")
+    |> String.replace(~r/(-{3})/, "-")
+    |> String.replace(~r/(&|\+)/, "and")
+    |> String.downcase()
+  end
+
+  defp change_spaces_to_dashes(str) do
+    str
+    |> String.split(" ")
+    |> Enum.join("-")
   end
 end

--- a/lib/cs_guide_web/controllers/venue_controller.ex
+++ b/lib/cs_guide_web/controllers/venue_controller.ex
@@ -88,6 +88,11 @@ defmodule CsGuideWeb.VenueController do
   end
 
   def update(conn, %{"slug" => slug, "venue" => venue_params}) do
+    if venue_params["venue_name"] || venue_params["postcode"] do
+      new_slug = Venue.create_slug(venue_params["venue_name"], venue_params["postcode"])
+      Map.put(venue_params, "slug", slug)
+    end
+
     venue =
       Venue.get_by(slug: slug) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
 

--- a/lib/cs_guide_web/controllers/venue_controller.ex
+++ b/lib/cs_guide_web/controllers/venue_controller.ex
@@ -88,10 +88,13 @@ defmodule CsGuideWeb.VenueController do
   end
 
   def update(conn, %{"slug" => slug, "venue" => venue_params}) do
-    if venue_params["venue_name"] || venue_params["postcode"] do
-      new_slug = Venue.create_slug(venue_params["venue_name"], venue_params["postcode"])
-      Map.put(venue_params, "slug", slug)
-    end
+    venue_params =
+      if venue_params["venue_name"] || venue_params["postcode"] do
+        new_slug = Venue.create_slug(venue_params["venue_name"], venue_params["postcode"])
+        Map.put(venue_params, "slug", new_slug)
+      else
+        venue_params
+      end
 
     venue =
       Venue.get_by(slug: slug) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
@@ -100,7 +103,7 @@ defmodule CsGuideWeb.VenueController do
       {:ok, venue} ->
         conn
         |> put_flash(:info, "Venue updated successfully.")
-        |> redirect(to: venue_path(conn, :show, slug))
+        |> redirect(to: venue_path(conn, :show, Map.get(venue_params, "slug", slug)))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", venue: venue, changeset: changeset)

--- a/lib/cs_guide_web/controllers/venue_controller.ex
+++ b/lib/cs_guide_web/controllers/venue_controller.ex
@@ -36,43 +36,46 @@ defmodule CsGuideWeb.VenueController do
   end
 
   def create(conn, %{"venue" => venue_params}) do
+    slug = Venue.create_slug(venue_params["venue_name"], venue_params["postcode"])
+    venue_params = Map.put(venue_params, "slug", slug)
+
     case Venue.insert(venue_params) do
       {:ok, venue} ->
         conn
         |> put_flash(:info, "Venue created successfully.")
-        |> redirect(to: venue_path(conn, :show, venue.entry_id))
+        |> redirect(to: venue_path(conn, :show, venue.slug))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(conn, %{"slug" => slug}) do
     venue =
-      id
-      |> Venue.get()
+      Venue.get_by(slug: slug)
       |> Venue.preload(
         drinks: [:brand, :drink_types, :drink_styles, :drink_images],
         venue_types: [],
         venue_images: []
       )
 
-    venue_owner = conn.assigns[:venue_id] == id
+    venue_owner = conn.assigns[:venue_id] == venue.id
     render(conn, "show.html", venue: venue, is_authenticated: conn.assigns[:admin] || venue_owner)
   end
 
-  def edit(conn, %{"id" => id}) do
-    venue = Venue.get(id) |> Venue.preload(:venue_types)
+  def edit(conn, %{"slug" => slug}) do
+    venue = Venue.get_by(slug: slug) |> Venue.preload(:venue_types)
     changeset = Venue.changeset(venue)
     render(conn, "edit.html", venue: venue, changeset: changeset)
   end
 
   def update(conn, %{
-        "id" => id,
+        "slug" => slug,
         "venue" => venue = %{"drinks" => drinks, "num_cocktails" => num_cocktails}
       })
       when map_size(venue) <= 2 do
-    venue = Venue.get(id) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
+    venue =
+      Venue.get_by(slug: slug) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
 
     venue_params =
       venue
@@ -84,14 +87,15 @@ defmodule CsGuideWeb.VenueController do
     do_update(conn, venue, venue_params)
   end
 
-  def update(conn, %{"id" => id, "venue" => venue_params}) do
-    venue = Venue.get(id) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
+  def update(conn, %{"slug" => slug, "venue" => venue_params}) do
+    venue =
+      Venue.get_by(slug: slug) |> Venue.preload([:venue_types, :venue_images, :drinks, :users])
 
     case Venue.update(venue, venue_params |> Map.put("drinks", venue.drinks)) do
       {:ok, venue} ->
         conn
         |> put_flash(:info, "Venue updated successfully.")
-        |> redirect(to: venue_path(conn, :show, venue.entry_id))
+        |> redirect(to: venue_path(conn, :show, slug))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", venue: venue, changeset: changeset)
@@ -126,17 +130,16 @@ defmodule CsGuideWeb.VenueController do
            ) do
       conn
       |> put_flash(:info, "Venue updated successfully.")
-      |> redirect(to: venue_path(conn, :show, venue.entry_id))
+      |> redirect(to: venue_path(conn, :show, venue.slug))
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", venue: venue, changeset: changeset)
     end
   end
 
-  def add_drinks(conn, %{"id" => id}) do
+  def add_drinks(conn, %{"slug" => slug}) do
     venue =
-      id
-      |> Venue.get()
+      Venue.get_by(slug: slug)
       |> Venue.preload(drinks: [:brand], venue_types: [])
 
     brands = Brand.all() |> Brand.preload(:drinks)
@@ -147,17 +150,17 @@ defmodule CsGuideWeb.VenueController do
       brands: brands,
       current_drinks: Enum.map(venue.drinks, fn d -> d.entry_id end),
       changeset: changeset,
-      action: venue_path(conn, :update, venue.entry_id)
+      action: venue_path(conn, :update, slug)
     )
   end
 
-  def add_photo(conn, %{"id" => id}) do
-    render(conn, "add_photo.html", id: id)
+  def add_photo(conn, %{"slug" => slug}) do
+    render(conn, "add_photo.html", slug: slug)
   end
 
   def upload_photo(conn, params) do
     CsGuide.Repo.transaction(fn ->
-      with {:ok, venue_image} <- VenueImage.insert(%{venue: params["id"]}),
+      with {:ok, venue_image} <- VenueImage.insert(%{venue: params["slug"]}),
            {:ok, _} <- CsGuide.Resources.upload_photo(params, venue_image.entry_id) do
         {:ok, venue_image}
       else
@@ -166,8 +169,8 @@ defmodule CsGuideWeb.VenueController do
       end
     end)
     |> case do
-      {:ok, _} -> redirect(conn, to: venue_path(conn, :show, params["id"]))
-      {:error, _} -> render(conn, "add_photo.html", id: params["id"], error: true)
+      {:ok, _} -> redirect(conn, to: venue_path(conn, :show, params["slug"]))
+      {:error, _} -> render(conn, "add_photo.html", id: params["slug"], error: true)
     end
   end
 

--- a/lib/cs_guide_web/router.ex
+++ b/lib/cs_guide_web/router.ex
@@ -36,10 +36,10 @@ defmodule CsGuideWeb.Router do
     get("/", PageController, :index)
     post("/signup", SignupController, :create)
 
-    resources("/users", UserController, only: [:new, :create])
-    resources("/venues", VenueController, only: [:show])
-    resources("/drinks", DrinkController, only: [:show])
     get("/brands/:name", BrandController, :show)
+    resources("/drinks", DrinkController, only: [:show])
+    resources("/users", UserController, only: [:new, :create])
+    get("/venues/:slug", VenueController, :show)
 
     resources("/sessions", SessionController, only: [:new, :create])
 
@@ -58,12 +58,12 @@ defmodule CsGuideWeb.Router do
     pipe_through([:browser, :admin])
 
     resources("/", AdminController, only: [:index])
+    resources("/brands", BrandController, except: [:show], param: "name")
+    resources("/drinks", DrinkController, except: [:show])
+    resources("/retailers", RetailerController, except: [:show])
     resources("/static_pages", StaticPageController, except: [:show], param: "page_title")
     resources("/users", UserController, except: [:new, :create])
-    resources("/venues", VenueController, only: [:index, :new, :create, :delete])
-    resources("/retailers", RetailerController, except: [:show])
-    resources("/drinks", DrinkController, except: [:show])
-    resources("/brands", BrandController, except: [:show], param: "name")
+    resources("/venues", VenueController, except: [:show], param: "slug")
 
     resources("/venue_types", VenueTypeController)
     resources("/drink_types", DrinkTypeController)
@@ -78,10 +78,10 @@ defmodule CsGuideWeb.Router do
 
   scope "/admin", CsGuideWeb do
     pipe_through([:browser, :venue_owner])
-    get("/venues/:id/add_drinks", VenueController, :add_drinks)
-    get("/venues/:id/add_photo", VenueController, :add_photo)
+    get("/venues/:slug/add_drinks", VenueController, :add_drinks)
+    get("/venues/:slug/add_photo", VenueController, :add_photo)
 
-    post("/venues/:id/", VenueController, :upload_photo)
+    post("/venues/:slug/", VenueController, :upload_photo)
     resources("/venues", VenueController, only: [:edit, :update])
   end
 

--- a/lib/cs_guide_web/templates/components/venue_card.html.eex
+++ b/lib/cs_guide_web/templates/components/venue_card.html.eex
@@ -1,5 +1,5 @@
 <div class="w-100 w-25-ns pb4">
-  <a class="cs-black no-underline pointer" href="<%= venue_path(@conn, :show, @venue.entry_id) %>">
+  <a class="cs-black no-underline pointer" href="<%= venue_path(@conn, :show, @venue.slug) %>">
     <div class="bg-green w-100 w-90-m w5-l h4 br2 mb2 bg-venue-card"
     <%= if img = List.last(@venue.venue_images) do %>
       style="background-image: url('https://s3-eu-west-1.amazonaws.com/<%=Application.get_env(:ex_aws, :bucket)%>/<%=img.entry_id%>');">

--- a/lib/cs_guide_web/templates/venue/add_photo.html.eex
+++ b/lib/cs_guide_web/templates/venue/add_photo.html.eex
@@ -1,7 +1,7 @@
 <section class="center w-80 w-75-l mv6">
   <h2 class="f4 lh4">Upload a photo for your venue</h2>
 
-  <%= form_for @conn, venue_path(@conn, :upload_photo, @id), [multipart: true], fn f -> %>
+  <%= form_for @conn, venue_path(@conn, :upload_photo, @slug), [multipart: true], fn f -> %>
     <div class="form-group mb4">
       <label class="db pt4 pb3">Select venue photo</label>
       <%= file_input f, :photo, class: "form-control" %>

--- a/lib/cs_guide_web/templates/venue/edit.html.eex
+++ b/lib/cs_guide_web/templates/venue/edit.html.eex
@@ -1,4 +1,4 @@
 <section class="center w-80 w-75-l mv6-ns mv5">
   <h2 class="f4 lh4">Edit Venue</h2>
-  <%= custom_render_autoform(@conn, :update, [CsGuide.Resources.Venue], assigns: [changeset: @changeset, venue: @venue], update_field: :entry_id, assoc_query: &query/1, exclude: [:entry_id, :deleted, :drinks, :cs_score, :num_cocktails, :venue_images, :users]) %>
+  <%= custom_render_autoform(@conn, :update, [CsGuide.Resources.Venue], assigns: [changeset: @changeset, venue: @venue], update_field: :slug, assoc_query: &query/1, exclude: [:entry_id, :deleted, :drinks, :cs_score, :num_cocktails, :venue_images, :users, :slug]) %>
 </section>

--- a/lib/cs_guide_web/templates/venue/index.html.eex
+++ b/lib/cs_guide_web/templates/venue/index.html.eex
@@ -28,10 +28,10 @@
           <td class="pa3 dn dib-ns"><%= DateTime.from_naive!(venue.inserted_at, "Etc/UTC") |> DateTime.to_date() %></td>
 
           <td class="pv3 pa3-ns tr">
-            <span><%= link "Show", to: venue_path(@conn, :show, venue.entry_id), class: "ph3 pv3-ns cs-mid-blue" %></span>
-            <span><%= link "Edit", to: venue_path(@conn, :edit, venue.entry_id), class: "ph3 pv3-ns cs-mid-blue" %></span>
+            <span><%= link "Show", to: venue_path(@conn, :show, venue.slug), class: "ph3 pv3-ns cs-mid-blue" %></span>
+            <span><%= link "Edit", to: venue_path(@conn, :edit, venue.slug), class: "ph3 pv3-ns cs-mid-blue" %></span>
             <span>
-              <%= link "Delete", to: venue_path(@conn, :delete, venue.entry_id),
+              <%= link "Delete", to: venue_path(@conn, :delete, venue.slug),
               method: :delete, data: [confirm: "Are you sure you'd like to delete this venue?"],
               class: "cs-mid-blue ph3 pv3-ns" %>
             </span>

--- a/lib/cs_guide_web/templates/venue/info.html.eex
+++ b/lib/cs_guide_web/templates/venue/info.html.eex
@@ -1,6 +1,6 @@
 <div class="w-90 w-60-ns pt4 ph5-ns center tr">
   <%= if @is_authenticated do %>
-    <%= link "Upload Photo", to: venue_path(@conn, :add_photo, @venue.entry_id), class: "dib dn-ns btn-primary no-underline" %>
+    <%= link "Upload Photo", to: venue_path(@conn, :add_photo, @venue.slug), class: "dib dn-ns btn-primary no-underline" %>
   <% end %>
   <div class="flex-ns items-center tl">
     <h1 class="roboto-slab f2 lh2 dib-ns"><%= @venue.venue_name %></h1>
@@ -12,9 +12,9 @@
     <img class="w4 v-btm" src="<%= static_path(@conn, "/images/score-#{@venue.cs_score}.png") %>" alt="Club Soda Score of <%= @venue.cs_score %>">
     <%= if @is_authenticated do %>
       <%= if @venue.cs_score == 5 do %>
-        <%= link "Is your stocklist up to date? Click here to update it.", to: venue_path(@conn, :add_drinks, @venue.entry_id), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
+        <%= link "Is your stocklist up to date? Click here to update it.", to: venue_path(@conn, :add_drinks, @venue.slug), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
       <% else %>
-        <%= link "Improve your score by adding more drinks to you stocklist.", to: venue_path(@conn, :add_drinks, @venue.entry_id), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
+        <%= link "Improve your score by adding more drinks to you stocklist.", to: venue_path(@conn, :add_drinks, @venue.slug), class: "cs-mid-blue dib mt2 mt0-ns pb1" %>
       <% end %>
     <% end %>
   </div>
@@ -26,7 +26,7 @@
     <p class="h5 bg-cs-light-gray pa3 mv4 mr5-ns br2 tl">
       <%= if @is_authenticated do %>
         No venue description,
-        <%= link "add description", to: venue_path(@conn, :edit, @venue.entry_id, class: "f6 lh6 cs-mid-blue dib v-top") %>
+        <%= link "add description", to: venue_path(@conn, :edit, @venue.slug, class: "f6 lh6 cs-mid-blue dib v-top") %>
       <% end %>
     </p>
   <% end %>

--- a/lib/cs_guide_web/templates/venue/link_under_map.html.eex
+++ b/lib/cs_guide_web/templates/venue/link_under_map.html.eex
@@ -13,7 +13,7 @@
     <% end %>
   <% else %>
     <%= if Map.has_key?(@conn.assigns, :is_authenticated) do %>
-      <%= link "Add venue " <> Atom.to_string(@link_key), to: venue_path(@conn, :edit, @venue.entry_id, class: "f6 lh6 cs-mid-blue dib v-top") %>
+      <%= link "Add venue " <> Atom.to_string(@link_key), to: venue_path(@conn, :edit, @venue.slug), class: "f6 lh6 cs-mid-blue dib v-top" %>
     <% end %>
   <% end %>
 </div>

--- a/lib/cs_guide_web/templates/venue/new.html.eex
+++ b/lib/cs_guide_web/templates/venue/new.html.eex
@@ -1,4 +1,4 @@
 <section class="center w-80 w-75-l mv5">
   <h2 class="f4 lh4">New Venue</h2>
-  <%= custom_render_autoform(@conn, :create, [CsGuide.Resources.Venue], assigns: [changeset: @changeset], exclude: [:deleted, :entry_id, :drinks, :num_cocktails, :cs_score, :venue_images, :users]) %>
+  <%= custom_render_autoform(@conn, :create, [CsGuide.Resources.Venue], assigns: [changeset: @changeset], exclude: [:deleted, :entry_id, :drinks, :num_cocktails, :cs_score, :venue_images, :users, :slug]) %>
 </section>

--- a/lib/cs_guide_web/templates/venue/show.html.eex
+++ b/lib/cs_guide_web/templates/venue/show.html.eex
@@ -1,6 +1,6 @@
 <section class="relative">
   <%= if @is_authenticated do %>
-    <%= link "Upload Photo", to: venue_path(@conn, :add_photo, @venue.entry_id), class: "dn db-ns absolute top-2 right-4 btn-primary no-underline" %>
+    <%= link "Upload Photo", to: venue_path(@conn, :add_photo, @venue.slug), class: "dn db-ns absolute top-2 right-4 btn-primary no-underline" %>
   <% end %>
   <section class="mt5">
 
@@ -55,7 +55,7 @@
             <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSyT_ehuzfLvJKLPOAVjobqWtZjFO1--mgpQb_NJmq0wIfpEc5SyXkuPxpG" alt="Photo of drink" class="w-5rem db center pt4">
             <p class="bg-cs-mint br2 ph3 pv2 white shadow-4 ml4 mv4 dib">% ABV</p>
           </div>
-          <%= link "Add Drinks", to: venue_path(@conn, :add_drinks, @venue.entry_id), class: "cs-mid-blue f5 lh5 tr pr4" %>
+          <%= link "Add Drinks", to: venue_path(@conn, :add_drinks, @venue.slug), class: "cs-mid-blue f5 lh5 tr pr4" %>
         </div>
       <% end %>
     </div>

--- a/priv/repo/add_venue_slug.exs
+++ b/priv/repo/add_venue_slug.exs
@@ -1,0 +1,7 @@
+alias CsGuide.Resources.Venue
+
+Venue.all()
+|> Enum.map(fn v ->
+  slug = Venue.create_slug(v.venue_name, v.postcode)
+  Venue.update(v, %{slug: slug})
+end)

--- a/priv/repo/migrations/20190108113325_adds_slug_to_venues.exs
+++ b/priv/repo/migrations/20190108113325_adds_slug_to_venues.exs
@@ -1,0 +1,9 @@
+defmodule CsGuide.Repo.Migrations.AddsSlugToVenues do
+  use Ecto.Migration
+
+  def change do
+    alter table(:venues) do
+      add(:slug, :string)
+    end
+  end
+end

--- a/test/cs_guide/postcode_lat_long_test.exs
+++ b/test/cs_guide/postcode_lat_long_test.exs
@@ -11,7 +11,8 @@ defmodule CsGuide.PostcodeLatLongTest do
       venue_types: %{"Pubs" => "on"},
       postcode: "E2 0SY",
       lat: "51.529675468124100",
-      long: "-0.042065456864592"
+      long: "-0.042065456864592",
+      slug: "the-favourite-pub-e2-0sy"
     },
     %{
       venue_name: "diff name, same location",
@@ -19,7 +20,8 @@ defmodule CsGuide.PostcodeLatLongTest do
       venue_types: %{"Pubs" => "on"},
       postcode: "E2 0SY",
       lat: "51.529675468124100",
-      long: "-0.042065456864592"
+      long: "-0.042065456864592",
+      slug: "the-favourite-pub-e2-0sy"
     }
   ]
 
@@ -33,11 +35,11 @@ defmodule CsGuide.PostcodeLatLongTest do
       Venue.get_by(venue_name: "The Not Favourite Pub")
       |> Venue.update(%{city: "London"})
 
-      query = from v in Venue, where: v.venue_name == "The Not Favourite Pub"
+      query = from(v in Venue, where: v.venue_name == "The Not Favourite Pub")
+
       all_not_fav_count =
         CsGuide.Repo.all(query)
         |> count_no_times_venue_occurs("The Not Favourite Pub")
-
 
       all_not_fav_count_from_nearest =
         PostcodeLatLong.nearest_venues(lat, long)

--- a/test/cs_guide/resources/resources_test.exs
+++ b/test/cs_guide/resources/resources_test.exs
@@ -16,19 +16,22 @@ defmodule CsGuide.ResourcesTest do
       phone_number: "01234567890",
       postcode: "EC1 5AD",
       venue_name: "some venue_name",
-      venue_types: %{@venue_type_name => "on"}
+      venue_types: %{@venue_type_name => "on"},
+      slug: "some-venue_name-ec1-5ad"
     }
     @update_attrs %{
       phone_number: "09876543210",
       postcode: "EC2 6FV",
       venue_name: "some updated venue_name",
-      venue_types: %{@venue_type_name => "on"}
+      venue_types: %{@venue_type_name => "on"},
+      slug: "some-venue_name-ec1-5ad"
     }
     @invalid_attrs %{
       phone_number: nil,
       postcode: nil,
       venue_name: nil,
-      venue_types: %{@venue_type_name => "on"}
+      venue_types: %{@venue_type_name => "on"},
+      slug: nil
     }
 
     def venue_fixture(attrs \\ %{}) do

--- a/test/cs_guide_web/controllers/page_controller_test.exs
+++ b/test/cs_guide_web/controllers/page_controller_test.exs
@@ -7,13 +7,15 @@ defmodule CsGuideWeb.PageControllerTest do
       venue_name: "The Favourite Pub",
       favourite: true,
       venue_types: %{"Pubs" => "on"},
-      postcode: "TW3 5FG"
+      postcode: "TW3 5FG",
+      slug: "the-favourite-pub-tw3-5fg"
     },
     %{
       venue_name: "The Not Favourite Pub",
       favourite: false,
       venue_types: %{"Pubs" => "on"},
-      postcode: "SW1 4RV"
+      postcode: "SW1 4RV",
+      slug: "the-not-favourite-pub-sw1-4rv"
     }
   ]
   describe "renders landing page as expected" do

--- a/test/cs_guide_web/controllers/search_all_controller_test.exs
+++ b/test/cs_guide_web/controllers/search_all_controller_test.exs
@@ -10,7 +10,8 @@ defmodule CsGuideWeb.SearchAllControllerTest do
       venue_name: "The Favourite Pub",
       favourite: true,
       venue_types: %{"Pubs" => "on"},
-      postcode: "TW3 5FG"
+      postcode: "TW3 5FG",
+      slug: "the-favourite-pub-tw3-5fg"
     }
   ]
 
@@ -51,7 +52,6 @@ defmodule CsGuideWeb.SearchAllControllerTest do
 
     drink
   end
-
 
   describe "search on venues and drinks" do
     setup [:create_venue, :drink_setup]

--- a/test/cs_guide_web/controllers/search_venue_controller_test.exs
+++ b/test/cs_guide_web/controllers/search_venue_controller_test.exs
@@ -9,7 +9,8 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
       venue_types: %{"Pubs" => "on"},
       postcode: "G1 1HF",
       lat: "55.858737212319600",
-      long: "-4.243474091424120"
+      long: "-4.243474091424120",
+      slug: "the-favourite-pub-g1-1hf"
     },
     %{
       venue_name: "The Not Favourite Pub",
@@ -17,7 +18,8 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
       venue_types: %{"Pubs" => "on"},
       postcode: "E2 0SY",
       lat: "51.529675468124100",
-      long: "-0.042065456864592"
+      long: "-0.042065456864592",
+      slug: "the-not-favourite-pub-e2-0sy"
     },
     %{
       venue_name: "same location as not fav",
@@ -25,7 +27,8 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
       venue_types: %{"Pubs" => "on"},
       postcode: "E2 0SY",
       lat: "51.529675468124100",
-      long: "-0.042065456864592"
+      long: "-0.042065456864592",
+      slug: "same-location-as-not-fav-e2-0sy"
     },
     %{
       venue_name: "The Retailer",
@@ -33,7 +36,8 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
       venue_types: %{"Retailers" => "on"},
       postcode: "SW1 4RV",
       lat: "51.468175746794700",
-      long: "-0.363049000000000"
+      long: "-0.363049000000000",
+      slug: "retailer"
     }
   ]
 
@@ -63,7 +67,8 @@ defmodule CsGuideWeb.SearchVenueControllerTest do
   describe "renders search/venues with nearby venues" do
     setup [:create_venue]
 
-    test "GET /search/venues?ll=(north london latlong) does not display venues that are too far", %{conn: conn} do
+    test "GET /search/venues?ll=(north london latlong) does not display venues that are too far",
+         %{conn: conn} do
       conn = get(conn, "/search/venues?ll=51.54359770000001,-0.08807799999999999")
 
       refute html_response(conn, 200) =~ "The Favourite Pub"

--- a/test/support/fixtures/fixtures.ex
+++ b/test/support/fixtures/fixtures.ex
@@ -20,7 +20,7 @@ defmodule CsGuide.Fixtures do
         postcode: "EC1 5AD",
         drinks: %{"AF Beer 1" => "on"},
         venue_types: %{"Bars" => "on"},
-        inserted_at: "2019-01-01 10:00:00.879083"
+        slug: "Venue-A-EC1-5AD"
       },
       %{
         venue_name: "Venue B",
@@ -30,7 +30,7 @@ defmodule CsGuide.Fixtures do
         postcode: "W6 8LY",
         drinks: %{"AF Beer 1" => "on"},
         venue_types: %{"Bars" => "on"},
-        inserted_at: "2019-01-04 10:00:00.879083"
+        slug: "Venue-B-W6-8LY"
       }
     ]
   end


### PR DESCRIPTION
#223 Gives venues readable slugs consisting of the venue name and postcode, removes special characters, replaces spaces with dashes

script `add_venue_slug.exs` will need running once deployed