### PR TITLE
on replace style/type drink delete, 

### DIFF
--- a/lib/cs_guide/resources/drink.ex
+++ b/lib/cs_guide/resources/drink.ex
@@ -28,14 +28,16 @@ defmodule CsGuide.Resources.Drink do
       :drink_types,
       CsGuide.Categories.DrinkType,
       join_through: "drinks_drink_types",
-      join_keys: [drink_id: :id, drink_type_id: :id]
+      join_keys: [drink_id: :id, drink_type_id: :id],
+      on_replace: :delete
     )
 
     many_to_many(
       :drink_styles,
       CsGuide.Categories.DrinkStyle,
       join_through: "drinks_drink_styles",
-      join_keys: [drink_id: :id, drink_style_id: :id]
+      join_keys: [drink_id: :id, drink_style_id: :id],
+      on_replace: :delete
     )
 
     has_many(:drink_images, CsGuide.Images.DrinkImage)


### PR DESCRIPTION
ref: https://github.com/club-soda/club-soda-guide/issues/332#issuecomment-453530607

When a style or type is removed from a drink delete the association in the database by using `on_replace` option instead of the default raised error.