### PR TITLE
#253 ensures padding doesn't show when there is no link

### DIFF
--- a/lib/cs_guide_web/templates/venue/link_under_map.html.eex
+++ b/lib/cs_guide_web/templates/venue/link_under_map.html.eex
@@ -1,5 +1,5 @@
-<div class="db pv1">
-  <%= if Map.get(@venue, @link_key) do %>
+<%= if Map.get(@venue, @link_key) do %>
+  <div class="db pv1">
     <img class="w-1-5rem dib pr2" src="<%= static_path(@conn, @img_str) %>" alt="<%= Atom.to_string(@link_key) %> icon">
     <%= if @link_key == :phone_number do %>
       <p class="f6 lh6 cs-mid-blue underline dib v-top">
@@ -12,8 +12,9 @@
     <% end %>
   <% else %>
     <%= if @is_authenticated do %>
-      <img class="w-1-5rem dib pr2" src="<%= static_path(@conn, @img_str) %>" alt="<%= Atom.to_string(@link_key) %> icon">
-      <%= link "Add venue " <> Atom.to_string(@link_key), to: venue_path(@conn, :edit, @venue.slug), class: "f6 lh6 cs-mid-blue dib v-top" %>
+      <div class="db pv1">
+        <img class="w-1-5rem dib pr2" src="<%= static_path(@conn, @img_str) %>" alt="<%= Atom.to_string(@link_key) %> icon">
+        <%= link "Add venue " <> Atom.to_string(@link_key), to: venue_path(@conn, :edit, @venue.slug), class: "f6 lh6 cs-mid-blue dib v-top" %>
     <% end %>
-  <% end %>
-</div>
+  </div>
+<% end %>


### PR DESCRIPTION
#253 ensures padding doesn't show when there is no social media link e.g. no instagram

<img src="https://user-images.githubusercontent.com/16775804/51471492-ca59c680-1d6e-11e9-8cd0-801b4cc2eb83.png" width=400px />
