### PR TITLE
#420 Includes unchanged values in social media fn

### DIFF
--- a/priv/repo/change_social_media_handles_to_urls.ex
+++ b/priv/repo/change_social_media_handles_to_urls.ex
@@ -12,6 +12,8 @@ update_social_url = fn el, social_media_brand, url_template ->
         cleaned_handle = String.slice(social_media_value, 1..-1)
 
         url_template <> cleaned_handle
+      else
+        social_media_value
       end
   end
 end
@@ -24,6 +26,8 @@ update_website = fn v ->
     website ->
       if String.starts_with?(website, "http") == false do
         "http://#{website}"
+      else
+        website
       end
   end
 end


### PR DESCRIPTION
#420 #344 Includes unchanged values in social media fn so that previously existing social media urls that were already in the correct format are not deleted.

Need to rerun script on staging once this is merged in.