### PR TITLE
Handles case of brand existing but not drink in new venue upload

### DIFF
--- a/priv/repo/new_venues.exs
+++ b/priv/repo/new_venues.exs
@@ -76,7 +76,7 @@ defmodule CsGuide.NewVenues do
                 drinks
 
               not_found_drink ->
-                IO.inspect("Drink not found: #{not_found_drink}")
+                IO.inspect("Brand not found: #{not_found_drink}")
                 acc
             end
           else
@@ -99,10 +99,18 @@ defmodule CsGuide.NewVenues do
                 drinks,
                 fn {d, b} ->
                   brand = Brand.get_by(name: b)
-                  drink = Drink.get_by(name: d, brand_id: brand.id)
-                  {drink.entry_id, "on"}
+
+                  case Drink.get_by(name: d, brand_id: brand.id) do
+                    nil ->
+                      IO.inspect("Drink not found: #{d}, brand: #{b}")
+                      nil
+
+                    drink ->
+                      {drink.entry_id, "on"}
+                  end
                 end
               )
+              |> Enum.filter(fn d -> not is_nil(d) end)
             )
           )
           |> (fn v ->


### PR DESCRIPTION
When testing venue upload script on staging, found a case where one of the drinks from the new venue list doesn't exist, but its brand does. This caused the script to error before completing.

This change catches that case, and also logs it so we can add the missing data manually if necessary.