### PR TITLE
Fixes update_cs_score file to retain venue types

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ The environment variable `IMPORT_FILES_DIR` should be the path to the directory 
 
 The files should be named correctly such that the format of the file matches the function that will be calling it. (That is, the brands file should be `brands.csv`, drinks `drinks.csv` and the venues `venues_1.csv`, `venues_2.csv` or `venues_3.csv`, depending on which format it is. These should be named correctly already, and as this import is only intended to be done once, shouldn't need to be changed. This documentation is just here as a guide if this import function ever needs to be extended.)
 
+If you do need to import more venues, use this script as a guide, but you will most likely have to create a new one based on the format of the csv file.
+
+After new venues have been imported, you may have to run `mix run priv/repo/update_cs_score.exs` if any drinks were attached to venues as part of the upload process.
+
 ### Creating Admin Users
 
 To create an admin user, open iex with `iex -S mix`.

--- a/priv/repo/update_cs_score.exs
+++ b/priv/repo/update_cs_score.exs
@@ -21,12 +21,15 @@ defmodule CsGuide.UpdateCsScore do
         venue.num_cocktails
       )
 
-    if venue.cs_score != calculatedScore do
-      Venue.update(venue, Map.put( %{drinks: venue.drinks}, :cs_score, calculatedScore ) )
+    if venue.cs_score != calculatedScore && map_size(venue.drinks) != 0 do
+      Venue.update(
+        venue,
+        venue |> Map.from_struct() |> Map.merge(%{cs_score: calculatedScore})
+      )
     end
   end
 end
 
 CsGuide.Resources.Venue.all()
-|> CsGuide.Resources.Venue.preload(:drinks)
-|> Enum.map(&(CsGuide.UpdateCsScore.update_cs_score(&1)))
+|> CsGuide.Resources.Venue.preload([:drinks, :venue_types, :users])
+|> Enum.map(&CsGuide.UpdateCsScore.update_cs_score(&1))


### PR DESCRIPTION
Update cs score script will no longer remove venue types or overwrite hardcoded cs scores given on initial venue upload.

ref #424