### PR TITLE
Adds Fever-Tree to brands with hyphens

### DIFF
--- a/lib/cs_guide_web/controllers/brand_controller.ex
+++ b/lib/cs_guide_web/controllers/brand_controller.ex
@@ -199,7 +199,7 @@ defmodule CsGuideWeb.BrandController do
   end
 
   defp check_brand_name(name) do
-    brands_with_hyphens = ~w(Fritz-Kola)
+    brands_with_hyphens = ~w(Fritz-Kola Fever-Tree)
 
     if Enum.any?(brands_with_hyphens, &(&1 == name)) do
       name


### PR DESCRIPTION
ref #435

Adds Fever-Tree to brands with hyphens function to allow it to show. 

This fixes it for now, but the same problem will occur again if another brand with a hyphen is added, so we should really come up with a long term solution.