### PR TITLE
#58 Changes brand image uploading UX

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,3 +24,4 @@ import "phoenix_html"
 require("./main.js")
 require("./carousel-swipe.js")
 require("./search.js")
+require("./photo-uploading.js")

--- a/assets/js/photo-uploading.js
+++ b/assets/js/photo-uploading.js
@@ -1,9 +1,12 @@
 var submitPhoto = document.getElementById("submit-photo");
-submitPhoto.addEventListener("click", displayUploading)
 
-function displayUploading(e) {
-  e.target.removeEventListener("click", displayUploading)
-  if (e.target.innerHTML) {
-    e.target.innerHTML = "Uploading..."
+if (submitPhoto) {  
+  submitPhoto.addEventListener("click", displayUploading)
+
+  function displayUploading(e) {
+    e.target.removeEventListener("click", displayUploading)
+    if (e.target.innerHTML) {
+      e.target.innerHTML = "Uploading..."
+    }
   }
 }

--- a/assets/js/photo-uploading.js
+++ b/assets/js/photo-uploading.js
@@ -1,0 +1,9 @@
+var submitPhoto = document.getElementById("submit-photo");
+submitPhoto.addEventListener("click", displayUploading)
+
+function displayUploading(e) {
+  e.target.removeEventListener("click", displayUploading)
+  if (e.target.innerHTML) {
+    e.target.innerHTML = "Uploading..."
+  }
+}

--- a/lib/cs_guide/images/brand_image.ex
+++ b/lib/cs_guide/images/brand_image.ex
@@ -6,7 +6,7 @@ defmodule CsGuide.Images.BrandImage do
   schema "brand_images" do
     field(:entry_id, :string)
     field(:deleted, :boolean, default: false)
-    field(:cover, :boolean)
+    field(:one, :boolean)
 
     belongs_to(:brand, CsGuide.Resources.Brand)
 
@@ -16,7 +16,7 @@ defmodule CsGuide.Images.BrandImage do
   @doc false
   def changeset(brand, attrs) do
     brand
-    |> cast(attrs, [:brand_id, :cover])
+    |> cast(attrs, [:brand_id, :one])
   end
 
   def insert(attrs) do

--- a/lib/cs_guide_web/router.ex
+++ b/lib/cs_guide_web/router.ex
@@ -73,6 +73,7 @@ defmodule CsGuideWeb.Router do
     resources("/discount_codes", DiscountCodeController)
 
     get("/drinks/:id/add_photo", DrinkController, :add_photo)
+    get("/brands/:name/add_cover_photo", BrandController, :add_cover_photo)
     get("/brands/:name/add_photo", BrandController, :add_photo)
 
     post("/drinks/:id/", DrinkController, :upload_photo)

--- a/lib/cs_guide_web/templates/brand/add_cover_photo.html.eex
+++ b/lib/cs_guide_web/templates/brand/add_cover_photo.html.eex
@@ -1,0 +1,4 @@
+<section class="center w-80 w-75-l mv6">
+  <h2 class="f4 lh4">Upload a cover photo for this brand</h2>
+  <%= component("image_upload", upload_type: "cover_photo", name: @name, conn: @conn) %>
+</section>

--- a/lib/cs_guide_web/templates/brand/add_photo.html.eex
+++ b/lib/cs_guide_web/templates/brand/add_photo.html.eex
@@ -1,21 +1,4 @@
 <section class="center w-80 w-75-l mv6">
   <h2 class="f4 lh4">Upload a photo for this brand</h2>
-
-  <%= form_for @conn, brand_path(@conn, :upload_photo, @name), [multipart: true], fn f -> %>
-    <div class="form-group mb4">
-      <label class="db pt4 pb3">Select brand photo</label>
-      <%= file_input f, :photo, class: "form-control" %>
-      <%= if assigns[:error] do %>
-      <p class="f5 lh5 red">Error uploading image, please try again or an alternative image.</p>
-      <% end %>
-    </div>
-
-    <%= label f, :cover, "Use as cover photo" %>
-    <%= checkbox(f, :cover) %>
-
-    <div class="form-group">
-      <%= submit "Submit", class: "btn btn-primary", id: "submit-photo" %>
-    </div>
-  <% end %>
-
+  <%= component("image_upload", upload_type: "body_photo", name: @name, conn: @conn) %>
 </section>

--- a/lib/cs_guide_web/templates/brand/add_photo.html.eex
+++ b/lib/cs_guide_web/templates/brand/add_photo.html.eex
@@ -14,7 +14,7 @@
     <%= checkbox(f, :cover) %>
 
     <div class="form-group">
-      <%= submit "Submit", class: "btn btn-primary" %>
+      <%= submit "Submit", class: "btn btn-primary", id: "submit-photo" %>
     </div>
   <% end %>
 

--- a/lib/cs_guide_web/templates/brand/edit.html.eex
+++ b/lib/cs_guide_web/templates/brand/edit.html.eex
@@ -3,7 +3,7 @@
 
 
   <%= custom_render_autoform(@conn, :update,
-    [{CsGuide.Resources.Brand, custom_labels: %{sold_aldi: "Sold on Aldi", sold_amazon: "Sold on Amazon", sold_asda: "Sold on Asda", sold_dd: "Sold on DryDrinker", sold_morrisons: "Sold on Morrisons", sold_sainsburys: "Sold on Sainsburys", sold_tesco: "Sold on Tesco", sold_waitrose: "Sold on Waitrose", sold_wb: "Sold on WiseBartender"}}], exclude: [:entry_id, :deleted, :drinks, :brand_images, :brand_images], custom_labels: %{sold_amazon: "Sold on Amazon YYYYY"}, path: brand_path(@conn, :update, @brand.name), assigns: [changeset: @changeset, brand: @brand], update_field: :entry_id, assoc_query: &query/1) %>
+    [{CsGuide.Resources.Brand, custom_labels: %{sold_aldi: "Sold on Aldi", sold_amazon: "Sold on Amazon", sold_asda: "Sold on Asda", sold_dd: "Sold on DryDrinker", sold_morrisons: "Sold on Morrisons", sold_sainsburys: "Sold on Sainsburys", sold_tesco: "Sold on Tesco", sold_waitrose: "Sold on Waitrose", sold_wb: "Sold on WiseBartender"}}], exclude: [:entry_id, :logo, :deleted, :drinks, :brand_images, :brand_images], custom_labels: %{sold_amazon: "Sold on Amazon YYYYY"}, path: brand_path(@conn, :update, @brand.name), assigns: [changeset: @changeset, brand: @brand], update_field: :entry_id, assoc_query: &query/1) %>
 
   <span><%= link "Back", to: brand_path(@conn, :index) %></span>
 </section>

--- a/lib/cs_guide_web/templates/brand/new.html.eex
+++ b/lib/cs_guide_web/templates/brand/new.html.eex
@@ -1,5 +1,5 @@
 <section class="center w-80 w-75-l mv6-ns mv5">
   <h2 class="f4 lh4">New Brand</h2>
-  <%= custom_render_autoform(@conn, :create, [{CsGuide.Resources.Brand, custom_labels: %{sold_aldi: "Sold on Aldi", sold_amazon: "Sold on Amazon", sold_asda: "Sold on Asda", sold_dd: "Sold on DryDrinker", sold_morrisons: "Sold on Morrisons", sold_sainsburys: "Sold on Sainsburys", sold_tesco: "Sold on Tesco", sold_waitrose: "Sold on Waitrose", sold_wb: "Sold on WiseBartender"}}], assigns: [changeset: @changeset], exclude: [:entry_id, :deleted, :drinks, :brand_images], update_field: :entry_id) %>
+  <%= custom_render_autoform(@conn, :create, [{CsGuide.Resources.Brand, custom_labels: %{sold_aldi: "Sold on Aldi", sold_amazon: "Sold on Amazon", sold_asda: "Sold on Asda", sold_dd: "Sold on DryDrinker", sold_morrisons: "Sold on Morrisons", sold_sainsburys: "Sold on Sainsburys", sold_tesco: "Sold on Tesco", sold_waitrose: "Sold on Waitrose", sold_wb: "Sold on WiseBartender"}}], assigns: [changeset: @changeset], exclude: [:entry_id, :logo, :deleted, :drinks, :brand_images], update_field: :entry_id) %>
   <span><%= link "Back", to: brand_path(@conn, :index) %></span>
 </section>

--- a/lib/cs_guide_web/templates/brand/show.html.eex
+++ b/lib/cs_guide_web/templates/brand/show.html.eex
@@ -1,9 +1,9 @@
 <section class="center mt5 mb6">
   <%= if @brand.member do %>
     <%= if @is_authenticated do %>
-      <%= link "Upload Photo", to: brand_path(@conn, :add_photo, @brand.name), class: "mt5 dn db-ns absolute top-2 right-4 btn-primary no-underline" %>
+      <%= link "Upload Photo", to: brand_path(@conn, :add_cover_photo, @brand.name), class: "mt3 dn db-ns absolute top-2 right-4 btn-primary no-underline" %>
     <% end %>
-    <%= if img = @brand.brand_images |> Enum.reverse |> Enum.find(fn i -> i.cover end) do %>
+    <%= if img = @brand.brand_images |> Enum.find(fn i -> i.one end) do %>
       <div class="db bg-venue w-100"
         style="background-image: url('https://s3-eu-west-1.amazonaws.com/<%=Application.get_env(:ex_aws, :bucket)%>/<%= img.entry_id %>');">
       </div>
@@ -96,13 +96,22 @@
   </section>
 
   <%= if @brand.member do %>
-    <section class="flex w-70-ns center">
-      <%= if img = @brand.brand_images |> Enum.reverse |> Enum.find(fn i -> !i.cover end) do %>
-        <div class="w-50-ns pa3 <%= if img do %>shadow-1<% end %>">
+    <section class="flex-ns w-70-ns center">
+      <%= if img = @brand.brand_images |> Enum.find(fn i -> !i.one end) do %>
+        <div class="w-90 w-50-ns pa3 relative center <%= if img do %>shadow-1<% end %>">
           <img class="w-100" src="https://s3-eu-west-1.amazonaws.com/<%=Application.get_env(:ex_aws, :bucket)%>/<%=img.entry_id%>" alt="Brand image">
+          <%= if @is_authenticated do %>
+          <%= link "Upload Photo", to: brand_path(@conn, :add_photo, @brand.name), class: "mt1 mr1 absolute top-1 right-1 btn-primary no-underline" %>
+          <% end %>
         </div>
+      <% else %>
+        <%= if @is_authenticated do %>
+        <div class="w-90 center pa3 w-40-ns tc shadow-1 h5 relative">
+          <%= link "Upload an image to accompany your text", to: brand_path(@conn, :add_photo, @brand.name), class: "absolute-center cs-mid-blue f6 lh6" %>
+        </div>
+        <% end %>
       <% end %>
-      <div class="w-50-ns pl4 lh6 f6">
+      <div class="w-50-ns pl4 lh6 f6 pt4 pt0-ns">
         <%= if @brand.copy do %>
           <p><%= @brand.copy %></p>
         <% else %>

--- a/lib/cs_guide_web/templates/components/image_upload.html.eex
+++ b/lib/cs_guide_web/templates/components/image_upload.html.eex
@@ -1,0 +1,13 @@
+<%= form_for @conn, brand_path(@conn, :upload_photo, @name), [multipart: true], fn f -> %>
+  <div class="form-group mb4">
+    <label class="db pt4 pb3">Select brand photo</label>
+    <%= file_input f, :photo, class: "form-control" %>
+    <%= if assigns[:error] do %>
+    <p class="f5 lh5 red">Error uploading image, please try again or an alternative image.</p>
+    <% end %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary", id: "submit-photo", name: @upload_type %>
+  </div>
+<% end %>

--- a/lib/cs_guide_web/templates/drink/add_photo.html.eex
+++ b/lib/cs_guide_web/templates/drink/add_photo.html.eex
@@ -11,7 +11,7 @@
     </div>
 
     <div class="form-group">
-      <%= submit "Submit", class: "btn btn-primary" %>
+      <%= submit "Submit", class: "btn btn-primary", id: "submit-photo" %>
     </div>
   <% end %>
 

--- a/lib/cs_guide_web/templates/venue/add_photo.html.eex
+++ b/lib/cs_guide_web/templates/venue/add_photo.html.eex
@@ -11,7 +11,7 @@
     </div>
 
     <div class="form-group">
-      <%= submit "Submit", class: "btn btn-primary" %>
+      <%= submit "Submit", class: "btn btn-primary", id: "submit-photo" %>
     </div>
   <% end %>
 

--- a/lib/cs_guide_web/templates/venue/show.html.eex
+++ b/lib/cs_guide_web/templates/venue/show.html.eex
@@ -30,7 +30,7 @@
         <%= under_map_link(@conn, :website, "/images/website-icon.png", @is_authenticated) %>
         <%= under_map_link(@conn, :facebook, "/images/facebook-icon.png", @is_authenticated) %>
         <%= under_map_link(@conn, :instagram, "/images/instagram-icon.png", @is_authenticated) %>
-        <%= under_map_link(@conn, :twitter, "/images/Twitter.svg", @is_authenticated) %>
+        <%= under_map_link(@conn, :twitter, "/images/twitter.svg", @is_authenticated) %>
 
         <!-- To be added at a later date, see #119 -->
         <!-- <h3 class="f4 lh4 pv3">Opening Hours</h3>

--- a/priv/repo/migrations/20190201104227_rename_brand_cover_img_as_one.exs
+++ b/priv/repo/migrations/20190201104227_rename_brand_cover_img_as_one.exs
@@ -1,0 +1,7 @@
+defmodule CsGuide.Repo.Migrations.RenameBrandCoverImgAsOne do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:brand_images), :cover, to: :one)
+  end
+end


### PR DESCRIPTION
#58 
- Changes brand image uploading UX so that rather than clicking the checkbox 'make cover image' to determine which brand image you are uploading, instead you click the button in the location on the 'show' page of the image that you would like to add/update.
- Adds 'uploading...' status on image upload click of submit btn
- Corrects twitter image broken path