### PR TITLE
format brand name for url

### DIFF
--- a/lib/cs_guide_web/templates/components/drink_card.html.eex
+++ b/lib/cs_guide_web/templates/components/drink_card.html.eex
@@ -20,7 +20,7 @@
       <div class="bb b--pink mt2 mh2 pb3 center">
         <h4 class="f4 lh4 mb1"><%= @drink.name %></h4>
         <p class="f5 lh5 mv1">by</p>
-        <%= link @drink.brand.name, to: brand_path(@conn, :show, @drink.brand.name), class: "f4 lh4 cs-mid-blue mv1" %>
+        <%= link @drink.brand.name, to: brand_path(@conn, :show, url_brand_name(@drink.brand.name)), class: "f4 lh4 cs-mid-blue mv1" %>
       </div>
       <div class="flex flex-wrap">
         <%= if @drink.drink_types do %>

--- a/lib/cs_guide_web/views/components_view.ex
+++ b/lib/cs_guide_web/views/components_view.ex
@@ -1,3 +1,9 @@
 defmodule CsGuideWeb.ComponentsView do
   use CsGuideWeb, :view
+
+  def url_brand_name(name) do
+    name
+    |> String.split("-") |> Enum.join("_")
+    |> String.split(" ") |> Enum.join("-")
+  end
 end


### PR DESCRIPTION
ref: #437 and #455

Use phoenix view function to convert the name of the brand to the url name.
This has been done for elm with #455 and this PR does it for the phoenix drink card template
