### PR TITLE
Adds colon after "Retailer" sub-title in discount code admin screens

### DIFF
--- a/lib/cs_guide_web/templates/discount_code/edit.html.eex
+++ b/lib/cs_guide_web/templates/discount_code/edit.html.eex
@@ -6,7 +6,7 @@
       {CsGuide.DiscountCode, exclude: [:entry_id, :deleted, :venue_id, :venue]},
     """
     <div class="form-group discount_code_venue_id-group">
-      <h4 class="pt2 pb2 f6 lh6">Retailer</h4>
+      <h4 class="pt2 pb2 f6 lh6">Retailer:</h4>
 
       <label for="discount_code_venue_name_DryDrinker" class="f6">DryDrinker</label>
       <input type="radio" id="discount_code_venue_name_drydrinker" name="discount_code[venue_name][DryDrinker]" class="form-control">

--- a/lib/cs_guide_web/templates/discount_code/new.html.eex
+++ b/lib/cs_guide_web/templates/discount_code/new.html.eex
@@ -5,7 +5,7 @@
     {CsGuide.DiscountCode, exclude: [:entry_id, :deleted, :venue_id, :venue]},
   """
   <div class="form-group discount_code_venue_id-group">
-  <h4 class="pt2 pb2 f6 lh6">Retailer</h4>
+  <h4 class="pt2 pb2 f6 lh6">Retailer:</h4>
 
     <label for="discount_code_venue_name_DryDrinker" class="f6">DryDrinker</label>
     <input type="radio" id="discount_code_venue_name_drydrinker" name="discount_code[venue_name]" value="DryDrinker" class="form-control">


### PR DESCRIPTION
@Cleop Was reviewing the dash and this situation in the discount code section was irking me a little (clearly not my day!):

![image](https://user-images.githubusercontent.com/4185328/52584900-40f85a00-2e2b-11e9-99d0-83ad469a0a9f.png)

So I added a colon in an attempt to 'clarify' that these were retailers (rather than making it a bigger heading because the next one up made it huge, or bold, because that would be inconsistent).

What do you reckon? Helpful or not really?

#217