### PR TITLE
Updates docs for post code search and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,17 +234,17 @@ post code and returns search results for venues _near_ this post code, within a
 30km radius.
 ![searching-for-full-post-code](https://user-images.githubusercontent.com/4185328/52587805-c8959700-2e32-11e9-8a8c-ede156ecd679.png)
 
-
 ### Drinks
 Example of a search on drinks with "beer"
 ![image](https://user-images.githubusercontent.com/6057298/49628671-77ee6180-f9dd-11e8-8946-300c0c5e91e4.png)
 
 The search is run **case insensitive** on the **name** and on the **description** of the drinks.
 
-When a drink type is selected, a pill is displayed above the "Drink Type" dropdown
-and allow the users to unselect the filter.
+When a drop-down is selected, a pill is displayed above the drop-down
+which allows the user to see which filters have been applied at a glance and
+also to quickly unselect them
 
-![image](https://user-images.githubusercontent.com/6057298/50681993-49c46780-1005-11e9-8348-c82b02a53378.png)
+![drink-type-filter-pills](https://user-images.githubusercontent.com/4185328/52588512-8c633600-2e34-11e9-8b80-1c50048b2bd1.png)
 
 ## Exporting to CSV
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,26 @@ best quality, but other sizes will be stretched or cropped to fit.
 
 ### Venues
 
+Venues can be searched for by venue name, location or _post code_ (see below).
+
+The search is run **case insensitive** on the **name** and **address** of the venues.
+The venues matching the search term are displayed first by _Club Soda Score_ (highest first)
+and then sorted alphabetically alphabetically.
+
 Example of a search on venues with "London"
 ![search venues](https://user-images.githubusercontent.com/6057298/49628521-6d7f9800-f9dc-11e8-9a38-5d62f4873d5e.png)
 
-The search is run **case insensitive** on the **name** of the venues. The venues matching the search term are displayed alphabetically.
+#### Searching by post code
+Searching for a **partial post code** works in the same way as the standard search
+and will display any venues and drinks found with this combination of letters and numbers
+in the name or address
+![searching-for-partial-post-code](https://user-images.githubusercontent.com/6057298/52043498-c597ce00-2537-11e9-8344-19eaa54dc9b7.png)
+
+Searching for a **full post code** calculates the latitude and longitude of that
+post code and returns search results for venues _near_ this post code, within a
+30km radius.
+![searching-for-full-post-code](https://user-images.githubusercontent.com/4185328/52587805-c8959700-2e32-11e9-8a8c-ede156ecd679.png)
+
 
 ### Drinks
 Example of a search on drinks with "beer"

--- a/lib/cs_guide_web/templates/discount_code/edit.html.eex
+++ b/lib/cs_guide_web/templates/discount_code/edit.html.eex
@@ -6,7 +6,7 @@
       {CsGuide.DiscountCode, exclude: [:entry_id, :deleted, :venue_id, :venue]},
     """
     <div class="form-group discount_code_venue_id-group">
-      <h4 class="pt2 pb2 f6 lh6">Retailer</h4>
+      <h4 class="pt2 pb2 f6 lh6">Retailer:</h4>
 
       <label for="discount_code_venue_name_DryDrinker" class="f6">DryDrinker</label>
       <input type="radio" id="discount_code_venue_name_drydrinker" name="discount_code[venue_name][DryDrinker]" class="form-control">

--- a/lib/cs_guide_web/templates/discount_code/new.html.eex
+++ b/lib/cs_guide_web/templates/discount_code/new.html.eex
@@ -5,7 +5,7 @@
     {CsGuide.DiscountCode, exclude: [:entry_id, :deleted, :venue_id, :venue]},
   """
   <div class="form-group discount_code_venue_id-group">
-  <h4 class="pt2 pb2 f6 lh6">Retailer</h4>
+  <h4 class="pt2 pb2 f6 lh6">Retailer:</h4>
 
     <label for="discount_code_venue_name_DryDrinker" class="f6">DryDrinker</label>
     <input type="radio" id="discount_code_venue_name_drydrinker" name="discount_code[venue_name]" value="DryDrinker" class="form-control">


### PR DESCRIPTION
I'd almost forgotten I'd done these because I didn't open the PR straight away!

Updates docs with:
+ Small update on venue searching
+ Post code searching for venues with information in https://github.com/club-soda/club-soda-guide/issues/274#issuecomment-459269918
+ Filtering (no longer only for the 'drink type' drop-down https://github.com/club-soda/club-soda-guide/issues/43

@SimonLab Could you please check through and confirm my understanding of this is correct before assigning to @nelsonic ?

