### PR TITLE
hide scrollbar on drink card

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -700,3 +700,12 @@ i {
   }
 }
 
+@media (min-width: 64em ){
+  .left-2-l {
+    left: 2rem;
+  }
+
+  .right-2-l {
+    right: 2rem;
+  }
+}

--- a/assets/elm/DrinkCard.elm
+++ b/assets/elm/DrinkCard.elm
@@ -21,7 +21,7 @@ drinkCard index d =
                 , input [ type_ "checkbox", name "card-front", id <| "display-back-" ++ String.fromInt index, class "display-back dn" ] []
                 , label [ for <| "display-back-" ++ String.fromInt index, class "cs-mid-blue f6 lh6 tr pr4 underline pointer" ] []
                 , div [ class "card-back-contents dn absolute top-0 left-0 bg-white pt3 ph3 w-100" ]
-                    [ div [ class "tl h-23rem h-25rem-l overflow-y-scroll" ]
+                    [ div [ class "tl h-23rem h-25rem-l overflow-y-auto" ]
                         [ div [ class "bb b--pink mt2 mh2 pb3 center" ]
                             [ h4 [ class "f4 lh4 mb1" ] [ text d.name ]
                             , p [ class "f5 lh5 mv1" ] [ text "by" ]

--- a/lib/cs_guide_web/templates/components/drink_card.html.eex
+++ b/lib/cs_guide_web/templates/components/drink_card.html.eex
@@ -16,7 +16,7 @@
   <label for="display-back-<%=@index%>" class="cs-mid-blue f6 lh6 tr pr4 underline pointer">  </label>
 
   <div class="card-back-contents dn absolute top-0 left-0 bg-white pt3 ph3 w-100">
-    <div class="tl h-23rem h-25rem-l overflow-y-scroll">
+    <div class="tl h-23rem h-25rem-l overflow-y-auto">
       <div class="bb b--pink mt2 mh2 pb3 center">
         <h4 class="f4 lh4 mb1"><%= @drink.name %></h4>
         <p class="f5 lh5 mv1">by</p>


### PR DESCRIPTION
 ref: https://github.com/club-soda/club-soda-guide/issues/459#issuecomment-467075680

If the content of the details on the drink card is "small", hide the scroll bar:
![image](https://user-images.githubusercontent.com/6057298/53404620-f4c22380-39ad-11e9-98a5-65f0e04ee063.png)
