### PR TITLE
Update brand on drink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: elixir
 elixir:
   - 1.7
+otp_release:
+  - 22.0
 env:
   - MIX_ENV=test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: elixir
 elixir:
   - 1.7
-otp_release:
-  - 22
 env:
   - MIX_ENV=test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 elixir:
   - 1.7
 otp_release:
-  - 20.2.4
+  - 22
 env:
   - MIX_ENV=test
 cache:

--- a/lib/cs_guide/resources/drink.ex
+++ b/lib/cs_guide/resources/drink.ex
@@ -91,6 +91,7 @@ defmodule CsGuide.Resources.Drink do
     |> CsGuide.Repo.preload(assocs)
     |> Map.put(:id, nil)
     |> Map.put(:updated_at, nil)
+    |> Map.put(:brand, nil)
     |> Resources.put_belongs_to_assoc(attrs, :brand, :brand_id, CsGuide.Resources.Brand, :name)
     |> __MODULE__.changeset(attrs)
     |> Resources.put_many_to_many_assoc(attrs, :drink_types, CsGuide.Categories.DrinkType, :name)


### PR DESCRIPTION
ref: #623

On the `update` function of `Resources.Drink` make sure that the association `brand` is set to `nil` to allow the `brand_id` property to be updated and to not have any conflict with the `brand` value