### PR TITLE
Empty string default value for title

### DIFF
--- a/lib/cs_guide_web/views/layout_view.ex
+++ b/lib/cs_guide_web/views/layout_view.ex
@@ -39,7 +39,7 @@ defmodule CsGuideWeb.LayoutView do
 
   def page_title(nil), do: "Club Soda Guide"
   def page_title(static_page) do
-    if String.trim(static_page.browser_title) == "" do
+    if String.trim(static_page.browser_title || "") == "" do
       "Club Soda Guide"
     else
       String.trim(static_page.browser_title)


### PR DESCRIPTION
ref: #592
It's possible that a static page doesn't have a browser title defined, in this case the function `String.trim/1` was raising an error as the parameter was nil. Use empty string if the browser title is not set