### PR TITLE
display new lines for drinks and brands description

### DIFF
--- a/assets/elm/DrinkCard.elm
+++ b/assets/elm/DrinkCard.elm
@@ -48,7 +48,7 @@ drinkCard index d =
                                 ]
                             , p [ class "dib bg-cs-mint br2 ph3 pv2 white shadow-4 mv2" ] [ text <| String.fromFloat d.abv ++ "% ABV" ]
                             ]
-                        , p [ class "pv2 f6 lh6" ]
+                        , p [ class "pv2 f6 lh6 wrap", style "white-space" "pre-wrap" ]
                             [ text d.description
                             ]
                         ]

--- a/lib/cs_guide_web/templates/brand/show.html.eex
+++ b/lib/cs_guide_web/templates/brand/show.html.eex
@@ -22,7 +22,7 @@
 
     <div class="w-90 w-70-m w-50-l center">
       <%= if @brand.description do %>
-        <p class="pv3 lh5"><%= raw @brand.description %></p>
+        <p class="pv3 lh5"><%= raw text_to_html(@brand.description) %></p>
       <% else %>
         <%= if @is_authenticated do %>
           <div class="pb3">


### PR DESCRIPTION
ref: #628
- use `text_to_html` function for the brand description in the phoenix template
- use the style `pre-wrap` for the drinks description in the Elm card 