### PR TITLE
use add_line_breaks instead of text_to_html

### DIFF
--- a/lib/cs_guide_web/templates/brand/show.html.eex
+++ b/lib/cs_guide_web/templates/brand/show.html.eex
@@ -22,7 +22,7 @@
 
     <div class="w-90 w-70-m w-50-l center">
       <%= if @brand.description do %>
-        <p class="pv3 lh5"><%= raw text_to_html(@brand.description) %></p>
+        <p class="pv3 lh5"><%= raw add_line_breaks(@brand.description) %></p>
       <% else %>
         <%= if @is_authenticated do %>
           <div class="pb3">

--- a/lib/cs_guide_web/views/brand_view.ex
+++ b/lib/cs_guide_web/views/brand_view.ex
@@ -3,7 +3,8 @@ defmodule CsGuideWeb.BrandView do
   use Autoform
 
   import Ecto.Query, only: [from: 2, subquery: 1]
-
+  import CsGuideWeb.VenueView, only: [add_line_breaks: 1]
+  
   def get_venues(brand) do
     brand.drinks
     |> Enum.map(fn d ->


### PR DESCRIPTION
ref: https://github.com/club-soda/club-soda-guide/issues/628#issuecomment-538442646

The Phoenix function `text_to_html` create new paragraph if there is 2 or more line breaks, however it will trim empty paragraphs.
So instead I'm using the helper function used for the venues `add_line_breaks` which will create `<br>` for every new lines