### PR TITLE
Updating joinclubsoda.co.uk to joinclubsoda.com on home page

### DIFF
--- a/lib/cs_guide_web/templates/page/index.html.eex
+++ b/lib/cs_guide_web/templates/page/index.html.eex
@@ -78,7 +78,7 @@
       <p class="roboto-slab f4 lh4 pb3">Special Offers, Drink Reviews, Recipes, Events and More</p>
       <a href="http://eepurl.com/dvVXfX" class="f4 lh4 pb3 cs-black">Get the Newsletter</a>
       <p class="f4 lh4 pt3">Find out more at</p>
-      <a class="f4 lh4 cs-black" target="_blank" href="https://joinclubsoda.co.uk/">joinclubsoda.co.uk</a>
+      <a class="f4 lh4 cs-black" target="_blank" href="https://joinclubsoda.com/">joinclubsoda.com</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Updating the text and link to the main Club Soda website from joinclubsoda.co.uk to joinclubsoda.com